### PR TITLE
feat: use native Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var Promise = require('native-or-bluebird');
-
 module.exports = function (ms) {
   return new Promise(function (resolve) {
     setTimeout(resolve, ms);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "index.js"
   ],
   "repository": "meoguru/then-sleep-js",
-  "dependencies": {
-    "native-or-bluebird": "^1.2.0"
+  "engine": {
+    "node": ">=4.0.0"
   }
 }


### PR DESCRIPTION
BREAKING: people with Node < 4 should use a polyfill such as [native-promise-only](https://github.com/getify/native-promise-only).

On Node, it's possible to use a specific promise implementation (only at application level), [Bluebird](http://bluebirdjs.com/docs/why-bluebird.html) for instance, to have better performance, by assigning `global.Promise`:

```js
global.Promise = require(bluebird)
```