### PR TITLE
Add async/await usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,25 @@ npm i then-sleep -S
 
 ## Usage
 
+### With `.then()`
+
 ```js
 var sleep = require('then-sleep');
 
 // Sleep for 1 second and do something then.
 sleep(1000).then(...);
+```
+
+### With `async/await`
+```js
+const sleep = require('then-sleep');
+
+async function sleepThenDoSomething() {
+  await sleep(1000);
+  ...
+}
+
+sleepThenDoSomething();
 ```
 
 ## License


### PR DESCRIPTION
zeit has a great example of using this module with `async/await` [here](https://github.com/zeit/micro#async--await); it would be nice if that same example were also present in the README!